### PR TITLE
Add the Sail model as another implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "riscv-implementations/riscv-isa-sim"]
 	path = riscv-implementations/riscv-isa-sim
 	url = git@github.com:CTSRD-CHERI/riscv-isa-sim.git
+[submodule "riscv-implementations/sail"]
+	path = riscv-implementations/sail
+	url = https://github.com/rems-project/sail.git
+	branch = rvfi-dii

--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,19 @@ spike-cheri:
 	../configure --with-fesvr=`pwd` --prefix=`pwd` --enable-rvfi-dii --enable-cheri --enable-cheri128 --enable-mergedrf --enable-misaligned &&\
 	make install && cp libfesvr.so lib/
 
-.PHONY: clean-riscv-implementations clean-rvbs
+sail:
+	$(MAKE) -C riscv-implementations/sail sail
+	$(MAKE) -C riscv-implementations/sail/riscv riscv_rvfi
 
-clean-riscv-implementations: clean-rvbs clean-spike
+.PHONY: clean-riscv-implementations clean-rvbs clean-sail
+
+clean-riscv-implementations: clean-rvbs clean-spike clean-sail
 
 clean-rvbs:
 	$(MAKE) -C riscv-implementations/RVBS mrproper-rvfi-dii
 
 clean-spike:
 	rm -rf riscv-implementations/riscv-isa-sim/build
+
+clean-sail:
+	$(MAKE) -C riscv-implementations/sail/riscv clean

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Currently, the provided modules are:
 - [BSV-RVFI-DII](https://github.com/CTSRD-CHERI/BSV-RVFI-DII.git)
 - [RVBS](https://github.com/CTSRD-CHERI/RVBS.git)
 - [Spike](https://github.com/CTSRD-CHERI/riscv-isa-sim.git)
+- [Sail RISC-V model](https://github.com/rems-project/sail)
 
 The root makefile can currently build the Quick Check Verification Engine, Spike, and the RVBS implementation.
 The dependencies for the Quick Check Verification Engine are:
@@ -67,3 +68,10 @@ The dependencies for Spike are:
 You can verify a default configuration by executing:
 - `make`
 - `utils/scripts/runTestRIG.py`
+
+The dependencies for the Sail model can be installed using
+[opam](http://opam.ocaml.org/) by following the instructions from the
+[Sail wiki](https://github.com/rems-project/sail/wiki/OPAMInstall).
+The Sail tool itself will be rebuilt by the module, so you can add
+`--deps-only` to the `opam install` command to avoid building it
+twice.

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -161,7 +161,10 @@ def spawn_rvfi_dii_server(name, port, log, arch="rv32i"):
       cmd += ["+itrace"]
   ##############################################################################
   elif (name == 'sail'):
-    cmd = [args.path_to_sail_riscv, "-m", "-r", str(port)]
+    if 'c' in isa:
+      cmd = [args.path_to_sail_riscv, "-m", "-r", str(port)]
+    else:
+      cmd = [args.path_to_sail_riscv, "-C", "-m", "-r", str(port)]
   ##############################################################################
   elif (name == 'manual'):
     return None

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -56,9 +56,9 @@ def auto_pos_int (x):
 def auto_write_fd (fname):
   return open(fname, 'w')
 
-known_rvfi_dii = set({'spike','rvbs','manual'})
+known_rvfi_dii = set({'spike','rvbs','sail','manual'})
 known_vengine  = set({'QCVEngine'})
-known_architectures = set({'rv32i','rv64i','rv32ixcheri'})
+known_architectures = set({'rv32i','rv64i','rv64ic','rv32ixcheri'})
 
 parser = argparse.ArgumentParser(description='Runs a TestRIG configuration')
 
@@ -103,6 +103,9 @@ parser.add_argument('--path-to-spike', metavar='PATH', type=str,
 parser.add_argument('--path-to-QCVEngine', metavar='PATH', type=str,
   #default='QCVEngine',
   default=op.join(op.dirname(op.realpath(__file__)), "../../vengines/QuickCheckVEngine/dist/build/QCVEngine/QCVEngine"),
+  help="The PATH to the QCVEngine executable")
+parser.add_argument('--path-to-sail-riscv', metavar='PATH', type=str,
+  default=op.join(op.dirname(op.realpath(__file__)), "../../riscv-implementations/sail/riscv/riscv_rvfi"),
   help="The PATH to the QCVEngine executable")
 parser.add_argument('-r', '--architecture', metavar='ARCH', choices=known_architectures,
   default='rv32i',
@@ -156,6 +159,9 @@ def spawn_rvfi_dii_server(name, port, log, arch="rv32i"):
     cmd = [args.path_to_rvbs]
     if log:
       cmd += ["+itrace"]
+  ##############################################################################
+  elif (name == 'sail'):
+    cmd = [args.path_to_sail_riscv, "-m", "-r", str(port)]
   ##############################################################################
   elif (name == 'manual'):
     return None


### PR DESCRIPTION
I've also added rv64ic as another supported architecture in the script, because the instruction alignment checks in sail and spike are different and turning on compressed instruction support works around that.