### PR TITLE
Various usability refreshes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,17 @@ clean: clean-vengines clean-riscv-implementations
 ################################################################################
 vengines: QCVEngine
 
-# Scripts expect the older build directory, so we have to use v1-build with newer cabal binaries
+QCVENGINE_BIN_DIR=$(CURDIR)/vengines/QuickCheckVEngine/bin
 QCVEngine: Makefile
-	cd vengines/QuickCheckVEngine &&\
-	if cabal --help 2>&1 | grep v1-build > /dev/null; then \
-	  (cabal v1-install --only-dependencies && cabal v1-configure && cabal -j$$(( `nproc` < 64 ? `nproc` : 64 )) v1-build); \
-	else \
-	  (cabal install --only-dependencies && cabal configure && cabal build); \
-	fi
+	( cd $(CURDIR)/vengines/QuickCheckVEngine && \
+	  cabal install --only-dependencies --overwrite-policy=always && \
+	  cabal configure && \
+	  cabal build )
+	$(eval QCVENGINE_BUILT = $(shell \
+	  cd $(CURDIR)/vengines/QuickCheckVEngine && \
+	  cabal list-bin QCVEngine ))
+	mkdir -p $(QCVENGINE_BIN_DIR)
+	cp $(QCVENGINE_BUILT) $(QCVENGINE_BIN_DIR)
 
 sail-generator:
 	cd vengines/sail-riscv-test-generation &&\

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -120,7 +120,7 @@ parser.add_argument('--implementation-A-log', metavar='PATH',
   help="Turn on logging for implementation A's rvfi-dii server (optionally specifying a file path)")
 # implementation args
 parser.add_argument('-b', '--implementation-B', metavar='IMP', choices=known_rvfi_dii,
-  default='qemu',
+  default='sail',
   help="The implementation B to use. (one of {:s})".format(str(known_rvfi_dii)))
 parser.add_argument('--implementation-B-port', metavar='PORT', type=auto_int, default=0,
   help="The port to use for implementation B's rvfi-dii server")

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -115,7 +115,7 @@ parser.add_argument('--implementation-A-log', metavar='PATH',
   help="Turn on logging for implementation A's rvfi-dii server (optionally specifying a file path)")
 # implementation args
 parser.add_argument('-b', '--implementation-B', metavar='IMP', choices=known_rvfi_dii,
-  default='sail',
+  default='qemu',
   help="The implementation B to use. (one of {:s})".format(str(known_rvfi_dii)))
 parser.add_argument('--implementation-B-port', metavar='PORT', type=auto_int, default=0,
   help="The port to use for implementation B's rvfi-dii server")
@@ -188,7 +188,7 @@ parser.add_argument('--csr-include-regex', type=str, metavar='regex',
   help="""A regex describing the subset of CSRs to include in tests, (defaults to all CSRs).""")
 parser.add_argument('--csr-exclude-regex', type=str, metavar='regex',
   help="""A regex describing the subset of CSRs to exclude (overriding csr-include-regex) on the verification engine, (defaults to no CSRs).""")
-parser.add_argument('--support-misaligned', action='store_true',
+parser.add_argument('--support-misaligned', action=argparse.BooleanOptionalAction, default=True,
   help="""Enable misaligned memory accesses""")
 parser.add_argument('--generator', metavar='GENERATOR', choices=known_generators,
   default='internal',

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -164,9 +164,7 @@ parser.add_argument('--path-to-muntjac', metavar='PATH', type=str,
   default=op.join(op.dirname(op.realpath(__file__)), "../../riscv-implementations/muntjac/bin/muntjac_core"),
   help="The PATH to the Muntjac executable")
 parser.add_argument('--path-to-QCVEngine', metavar='PATH', type=str,
-  #default='QCVEngine',
-  default=op.join(op.dirname(op.realpath(__file__)), "../../vengines/QuickCheckVEngine/dist/build/QCVEngine/QCVEngine"),
-  #default=op.join(op.dirname(op.realpath(__file__)), "../../vengines/QuickCheckVEngine/dist-newstyle/build/x86_64-linux/ghc-8.6.3/QCVEngine-0.1.0.0/x/QCVEngine/build/QCVEngine/QCVEngine"),
+  default=op.join(op.dirname(op.realpath(__file__)), "../../vengines/QuickCheckVEngine/bin/QCVEngine"),
   help="The PATH to the QCVEngine executable")
 parser.add_argument('--path-to-sail-riscv-dir', metavar='PATH', type=str,
   default=None,  # This value is set to None so that later it can be set depending on whether CHERI is enabled or not.


### PR DESCRIPTION
I tried to have a brief go at catching a few stale things here and there.

@marnovandermaas @elliotb-lowrisc I happen to also have touched something you guys seem to have been interacting with apparently. Do have a look at what I have done in 18c002348e437ce065719eb58c5fe06aaa3ca044.
Unless we pass a specific qcvengine to the runscript, we should just draw a line in the sand and expect some agreed upon fixed location to the binary. Rather than silently have that location be "the one that some old version of cabal wanted" and have the think about how things should be each time a new toolchain changes that path, we just get cabal to tell us where it put the binary and copy it to where we want it when we build. (and for what it's worth, 02a337ee786df0e86c08740bd9ee3eb08e78f7e1 cleans up the run script a bit further).