### PR TITLE
Changed default behaviour of support misaligned

### DIFF
--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -213,6 +213,11 @@ parser.add_argument('--relaxed-comparison', action='count', default=0,
   help="Compare a reduced set of RVFI fields in VEngine")
 parser.add_argument('--strict-comparison', action='count', default=0,
   help="Compare all RVFI fields in VEngine")
+parser.add_argument('--relaxed-comparison', action='count', default=0,
+  help="Comparea reduced set of RVFI fields in VEngine")
+parser.add_argument('--strict-comparison', action='count', default=0,
+  help="Compare all RVFI fields in VEngine")
+>>>>>>> ee834b1 (Added default to be relaxed comparison; also added option for strict comparison)
 parser.add_argument('--no-shrink', action='count', default=0,
   help="Disable VEngine test case shrinking")
 parser.add_argument('--no-save', action='count', default=0,

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -213,11 +213,6 @@ parser.add_argument('--relaxed-comparison', action='count', default=0,
   help="Compare a reduced set of RVFI fields in VEngine")
 parser.add_argument('--strict-comparison', action='count', default=0,
   help="Compare all RVFI fields in VEngine")
-parser.add_argument('--relaxed-comparison', action='count', default=0,
-  help="Comparea reduced set of RVFI fields in VEngine")
-parser.add_argument('--strict-comparison', action='count', default=0,
-  help="Compare all RVFI fields in VEngine")
->>>>>>> ee834b1 (Added default to be relaxed comparison; also added option for strict comparison)
 parser.add_argument('--no-shrink', action='count', default=0,
   help="Disable VEngine test case shrinking")
 parser.add_argument('--no-save', action='count', default=0,

--- a/utils/scripts/runTestRIG.py
+++ b/utils/scripts/runTestRIG.py
@@ -192,7 +192,7 @@ parser.add_argument('--csr-include-regex', type=str, metavar='regex',
   help="""A regex describing the subset of CSRs to include in tests, (defaults to all CSRs).""")
 parser.add_argument('--csr-exclude-regex', type=str, metavar='regex',
   help="""A regex describing the subset of CSRs to exclude (overriding csr-include-regex) on the verification engine, (defaults to no CSRs).""")
-parser.add_argument('--support-misaligned', action=argparse.BooleanOptionalAction, default=True,
+parser.add_argument('--support-misaligned', action=argparse.BooleanOptionalAction, default=False,
   help="""Enable misaligned memory accesses""")
 parser.add_argument('--generator', metavar='GENERATOR', choices=known_generators,
   default='internal',


### PR DESCRIPTION
It is more common to not support misaligned memory accesses. If needed, implementations can be provided with `--support-misaligned`